### PR TITLE
[WIP BUGFIX] Respect EmberApp outputPaths option for style trees

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,8 @@ EmberCLILESS.prototype.included = function included(app) {
   if ((options.sourceMap === undefined) && (app.env === 'development')) {
     options.sourceMap = true;
   }
-  options.outputFile = options.outputFile || this.project.name() + '.css';
+  var appOutputPaths = app.options.outputPaths.app;
+  options.outputFile = options.outputFile || appOutputPaths.less || appOutputPaths.css;
   app.registry.add('css', new LESSPlugin(options));
 };
 


### PR DESCRIPTION
Before this was extracted, ember-cli [respected the outputPath](https://github.com/stefanpenner/ember-cli/pull/1904) provided for CSS, e.g.

```javascript
var app = new EmberApp({
  outputPaths: {
    app: {
      css: '/some-path/app.css'
      // or
      less: '/some-path/app.css'
    }
});
```
If the path isn't provided by the user's broc it defaults to the project name, just like your code does now.

This PR adds ability back while also allowing them to use `less` instead, which might be more accurate, even if not backwards compatible?
