### PR TITLE
Support multiple outputPaths defined in Brocfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   "author": "Garth Poitras",
   "license": "MIT",
   "dependencies": {
-    "broccoli-less-single": "^0.1.5"
+    "broccoli-less-single": "^0.1.5",
+    "broccoli-merge-trees": "^0.2.1",
+    "lodash-node": "^2.4.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds support for defining multiple outputPaths in the Brocfile, useful for outputting multiple themes:
```
var app = new EmberApp({
   outputPaths: {
    app: {
      css: {
        'theme-orange': '/assets/theme-orange.css',
        'theme-purple': '/assets/theme-purple.css'
      }
    }
  }
});
```
Note: if this config is not defined it defaults to looking for app/styles/app.less