### PR TITLE
Only rebuild LESS, when a LESS file has been changed

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,10 +15,11 @@ LESSPlugin.prototype.toTree = function(tree, inputPath, outputPath, options) {
   var paths = options.outputPaths || { app: options.registry.app.options.outputPaths.app.css };
 
   var trees = Object.keys(paths).map(function(file) {
-    var input = path.join(inputPath, file + '.' + ext);
+    var sourceFileName = file + '.' + ext;
     var output = paths[file];
+    var sourceFolderAbsolutePath = path.resolve('.' + inputPath);
 
-    return new LESSCompiler([tree], input, output, options);
+    return new LESSCompiler([sourceFolderAbsolutePath], sourceFileName, output, options);
   });
 
   return mergeTrees(trees);


### PR DESCRIPTION
I've changed the build, so it only watches the styles directory. It works fine on Windows. I'm unable to verify it on Mac / Linux, so please have a look and let me know if this is good to go.

Fixes #10.