### PR TITLE
Support usage as a precompiler for ember addons

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ var app = new EmberApp({
 - `paths`: an array of include paths
 - `sourceMap`: whether to generate source maps. Defaults to `true` in development.
 
+## Usage in Addons
+
+You can also use this to precompile LESS files in an addon. By default, this
+will compile `addon/styles/addon.less` into a CSS file that can be used by the
+host app. *(requires ember-cli >= 0.2.0)*:
+
+To use `ember-cli-less` this way, specify it under the `dependencies` hash in
+your addon's `package.json`.
+
 ## Configuring Input/Output Paths
 
 You can configure the input and output files using ember-cli's `outputPaths` option in `Brocfile.js` *(requires ember-cli >= 0.1.13)*:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "broccoli-less-single": "0.2.0",
     "broccoli-merge-trees": "^0.2.1",
-    "lodash-node": "^2.4.1"
+    "lodash-node": "^2.4.1",
+    "ember-cli-version-checker": "^1.0.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This supports usage within ember addons.

An ember addon can use LESS (by creating a file `addon/styles/addon.less`), then use `ember-cli-less` so that its LESS will be compiled and merged with host app CSS during the build process.

To use `ember-cli-less` in an addon, just add it to `dependencies` in `package.json` (example: https://github.com/Addepar/ember-table-addon/blob/azirbel/convert-src/package.json#L21).

We use `setupPreprocessorRegistry` here. This hook is only available in Ember CLI 0.2.0, so usage in ember addons will not work in earlier versions of Ember CLI.

The standard usage in ember apps will continue to work in Ember CLI 1.x, using the `included` hook.

I've tested basic usage in addons for Ember CLI 0.2.0, and basic usage in apps for Ember CLI 0.1.15 and 0.2.0. However, I'm new to broccoli and could be missing a common use case for this addon.

I've based my changes on `ember-cli-sass`, since the README mentions that it was inspiration for this project. As I added the new hook, I restructured the code somewhat to mirror the format there.