### PR TITLE
Allow setting lessOptions variable on ENV variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,10 @@ npm install --save-dev ember-cli-less
 ## Usage
 
 By default, this addon will compile `app/styles/app.less` into `dist/assets/app.css`.  
-Additional options can be specified using the `lessOptions` config property in `Brocfile.js`:
+Additional options can be specified using the `lessOptions` config property in `config/environment.js`:
 
 ```javascript
-var app = new EmberApp({
-  lessOptions: {...}
-});
+ENV.lessOptions = {...}
 ```
 
 **Options:**  

--- a/index.js
+++ b/index.js
@@ -38,7 +38,8 @@ module.exports = {
 
   lessOptions: function() {
     var env = process.env.EMBER_ENV;
-    var options =  (this.app && this.app.options.lessOptions) || {};
+    var options = this.project.config(env).lessOptions || 
+        (this.app && this.app.options.lessOptions) || {};
 
     if ((options.sourceMap === undefined) && (env === 'development')) {
       options.sourceMap = true;


### PR DESCRIPTION
Look for lessOptions variable on emberCLI ENV variable first, before looking for it on EmberApp object. This matches updated functionality from ember-cli-sass addon.

This solves issue with Ember addon use where options variable was not found on app object. Also, this allows LESS settings to be set on each environment.