### PR TITLE
Don't install all of lodash

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var LESSCompiler = require('broccoli-less-single');
 var path         = require('path');
-var merge        = require('lodash-node/modern/objects/merge');
+var merge        = require('lodash.merge');
 var mergeTrees   = require('broccoli-merge-trees');
 var checker      = require('ember-cli-version-checker');
 

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
   "license": "MIT",
   "dependencies": {
     "broccoli-less-single": "^0.3.0",
-    "broccoli-merge-trees": "^0.2.1",
+    "broccoli-merge-trees": "^0.2.3",
     "ember-cli-version-checker": "^1.0.2",
-    "lodash-node": "^2.4.1"
+    "lodash.merge": "^3.3.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Since we're only using `lodash.merge`, so install that only.