### PR TITLE
Add option for mergeTrees configuration, fixes #32

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ take an object of sub options: http://lesscss.org/usage/#programmatic-usage
 ## Configuring Input/Output Paths
 
 You can configure the input and output files using ember-cli's `outputPaths` option in `ember-cli-build.js`:
+
 ```javascript
 var app = new EmberApp({
   outputPaths: {
@@ -51,9 +52,16 @@ var app = new EmberApp({
         'theme-purple': '/assets/theme-purple.css'
       }
     }
+  },
+  lessOptions: {
+    mergeTrees: {
+      overwrite: true
+    }
   }
 });
 ```
+
+Notice that the `mergeTrees.overwrite` option is currently required for this to work.
 
 ## Usage in Addons
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ var app = new EmberApp({
 - `paths`: an array of include paths
 - `sourceMap`: whether to generate source maps. Defaults to `true` in development.  sourceMap can also
 take an object of sub options: http://lesscss.org/usage/#programmatic-usage
+- `mergeTrees`: an object of the available options to pass to the internal [merge trees] plugin
 
 ## Configuring Input/Output Paths
 
@@ -105,3 +106,5 @@ your local filesystem in Chrome:
 - Code inspired by: [ember-cli-sass](https://github.com/aexmachina/ember-cli-sass). Credits to the author.
 - [broccoli-less-single](https://github.com/gabrielgrant/broccoli-less-single)
 - [less](https://github.com/less/less.js)
+
+[merge trees]: https://github.com/broccolijs/broccoli-merge-trees#options

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ LESSPlugin.prototype.toTree = function(tree, inputPath, outputPath, inputOptions
     return new LESSCompiler([tree], input, output, options);
   });
 
-  return mergeTrees(trees);
+  return mergeTrees(trees, options.mergeTrees);
 };
 
 module.exports = {


### PR DESCRIPTION
Basically expose the options for the internal merge trees plugin.

Related to #32 