### PR TITLE
add workaround for lessOptions in nested addons

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,14 @@ module.exports = {
   lessOptions: function() {
     var env = process.env.EMBER_ENV;
     var app = this.app;
+
+    // fix issue with nested addons, in which case our app.options hash is actually on app.app.options.
+    // n.b. this can be removed once ember-cli better supports nested addons.
+    //   (see https://github.com/gdub22/ember-cli-less/issues/36)
+    if (!app.options && app.app && app.app.options) {
+        app = app.app;
+    }
+
     var options = (app && app.options && app.options.lessOptions) || {};
 
     if ((options.sourceMap === undefined) && (env === 'development')) {


### PR DESCRIPTION
Added workaround to get `options.paths` working when used in nested ember-cli addons. (See https://github.com/gdub22/ember-cli-less/issues/36.)